### PR TITLE
Update Go version and manage module dependencies

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -27,12 +27,18 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5.0.2
         with:
-          go-version: '1.20'
+          go-version: '1.21.x'
 
+      # Initialize Go Module
       - name: Initialize Go Module
         run: go mod init github.com/cdot65/pan-os-cdss-certificate-registration
 
-      - name: Download dependencies
+      # Clear module cache
+      - name: Clear module cache
+        run: go clean -modcache
+
+      # Tidy up dependencies
+      - name: Tidy Go Module
         run: go mod tidy
 
       - name: Build Binary


### PR DESCRIPTION
Upgraded Go version from 1.20 to 1.21.x in the GitHub action workflow. Added steps to clear the Go module cache and tidy up the dependencies to ensure a clean and streamlined module environment.