### PR TITLE
Report only

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -3,48 +3,11 @@ package config
 
 import (
 	"encoding/xml"
-	"flag"
 	"fmt"
 	"os"
-	"runtime"
 
 	"gopkg.in/yaml.v2"
 )
-
-// Flags represents the command-line flags
-type Flags struct {
-	DebugLevel     int
-	Concurrency    int
-	ConfigFile     string
-	SecretsFile    string
-	HostnameFilter string
-	Verbose        bool
-	NoPanorama     bool
-}
-
-// setupFlags sets up the flags without parsing them
-func setupFlags(fs *flag.FlagSet, cfg *Flags) {
-	fs.IntVar(&cfg.DebugLevel, "debug", 0, "Debug level: 0=INFO, 1=DEBUG")
-	fs.IntVar(&cfg.Concurrency, "concurrency", runtime.NumCPU(), "Number of concurrent operations")
-	fs.StringVar(&cfg.ConfigFile, "config", "panorama.yaml", "Path to the Panorama configuration file")
-	fs.StringVar(&cfg.SecretsFile, "secrets", ".secrets.yaml", "Path to the secrets file")
-	fs.StringVar(&cfg.HostnameFilter, "filter", "", "Comma-separated list of hostname patterns to filter devices")
-	fs.BoolVar(&cfg.Verbose, "verbose", false, "Enable verbose logging")
-	fs.BoolVar(&cfg.NoPanorama, "nopanorama", false, "Use inventory.yaml instead of querying Panorama")
-}
-
-// ParseFlags parses command-line flags and returns a configuration object.
-func ParseFlags() (*Flags, *Config) {
-	cfg := &Flags{}
-	setupFlags(flag.CommandLine, cfg)
-	flag.Parse()
-
-	config := &Config{
-		HostnameFilter: cfg.HostnameFilter,
-	}
-
-	return cfg, config
-}
 
 // Panorama represents the configuration details for Panorama.
 type Panorama struct {
@@ -57,6 +20,7 @@ type Config struct {
 	} `yaml:"panorama"`
 	Auth           AuthConfig
 	HostnameFilter string
+	ReportOnly     bool
 }
 
 // AuthConfig represents the authentication configuration.

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,83 +1,13 @@
 package config
 
 import (
-	"flag"
 	"os"
 	"reflect"
-	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
-
-func createTestFlags() *Flags {
-	return &Flags{
-		DebugLevel:     0,
-		Concurrency:    runtime.NumCPU(),
-		ConfigFile:     "panorama.yaml",
-		SecretsFile:    ".secrets.yaml",
-		HostnameFilter: "",
-		Verbose:        false,
-		NoPanorama:     false,
-	}
-}
-
-func TestSetupFlags(t *testing.T) {
-	tests := []struct {
-		name     string
-		args     []string
-		expected *Flags
-	}{
-		{
-			name: "Default values",
-			args: []string{},
-			expected: &Flags{
-				DebugLevel:     0,
-				Concurrency:    runtime.NumCPU(),
-				ConfigFile:     "panorama.yaml",
-				SecretsFile:    ".secrets.yaml",
-				HostnameFilter: "",
-				Verbose:        false,
-				NoPanorama:     false,
-			},
-		},
-		{
-			name: "Custom values",
-			args: []string{
-				"-debug", "1",
-				"-concurrency", "4",
-				"-config", "custom.yaml",
-				"-secrets", "custom_secrets.yaml",
-				"-filter", "fw-*",
-				"-verbose",
-				"-nopanorama",
-			},
-			expected: &Flags{
-				DebugLevel:     1,
-				Concurrency:    4,
-				ConfigFile:     "custom.yaml",
-				SecretsFile:    "custom_secrets.yaml",
-				HostnameFilter: "fw-*",
-				Verbose:        true,
-				NoPanorama:     true,
-			},
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			fs := flag.NewFlagSet("test", flag.ContinueOnError)
-			cfg := &Flags{}
-			setupFlags(fs, cfg)
-
-			err := fs.Parse(tt.args)
-			require.NoError(t, err)
-
-			assert.Equal(t, tt.expected, cfg)
-		})
-	}
-}
 
 func TestLoad(t *testing.T) {
 	tests := []struct {

--- a/config/flags.go
+++ b/config/flags.go
@@ -1,0 +1,44 @@
+package config
+
+import (
+	"flag"
+	"runtime"
+)
+
+// Flags represents the command-line flags
+type Flags struct {
+	DebugLevel     int
+	Concurrency    int
+	ConfigFile     string
+	SecretsFile    string
+	HostnameFilter string
+	Verbose        bool
+	NoPanorama     bool
+	ReportOnly     bool
+}
+
+// setupFlags sets up the flags without parsing them
+func setupFlags(fs *flag.FlagSet, cfg *Flags) {
+	fs.IntVar(&cfg.DebugLevel, "debug", 0, "Debug level: 0=INFO, 1=DEBUG")
+	fs.IntVar(&cfg.Concurrency, "concurrency", runtime.NumCPU(), "Number of concurrent operations")
+	fs.StringVar(&cfg.ConfigFile, "config", "panorama.yaml", "Path to the Panorama configuration file")
+	fs.StringVar(&cfg.SecretsFile, "secrets", ".secrets.yaml", "Path to the secrets file")
+	fs.StringVar(&cfg.HostnameFilter, "filter", "", "Comma-separated list of hostname patterns to filter devices")
+	fs.BoolVar(&cfg.Verbose, "verbose", false, "Enable verbose logging")
+	fs.BoolVar(&cfg.NoPanorama, "nopanorama", false, "Use inventory.yaml instead of querying Panorama")
+	fs.BoolVar(&cfg.ReportOnly, "reportonly", false, "Run in report-only mode without connecting to devices")
+}
+
+// ParseFlags parses command-line flags and returns a configuration object.
+func ParseFlags() (*Flags, *Config) {
+	cfg := &Flags{}
+	setupFlags(flag.CommandLine, cfg)
+	flag.Parse()
+
+	config := &Config{
+		HostnameFilter: cfg.HostnameFilter,
+		ReportOnly:     cfg.ReportOnly,
+	}
+
+	return cfg, config
+}

--- a/config/flags_test.go
+++ b/config/flags_test.go
@@ -1,0 +1,77 @@
+package config
+
+import (
+	"flag"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"runtime"
+	"testing"
+)
+
+func createTestFlags() *Flags {
+	return &Flags{
+		DebugLevel:     0,
+		Concurrency:    runtime.NumCPU(),
+		ConfigFile:     "panorama.yaml",
+		SecretsFile:    ".secrets.yaml",
+		HostnameFilter: "",
+		Verbose:        false,
+		NoPanorama:     false,
+	}
+}
+
+func TestSetupFlags(t *testing.T) {
+	tests := []struct {
+		name     string
+		args     []string
+		expected *Flags
+	}{
+		{
+			name: "Default values",
+			args: []string{},
+			expected: &Flags{
+				DebugLevel:     0,
+				Concurrency:    runtime.NumCPU(),
+				ConfigFile:     "panorama.yaml",
+				SecretsFile:    ".secrets.yaml",
+				HostnameFilter: "",
+				Verbose:        false,
+				NoPanorama:     false,
+			},
+		},
+		{
+			name: "Custom values",
+			args: []string{
+				"-debug", "1",
+				"-concurrency", "4",
+				"-config", "custom.yaml",
+				"-secrets", "custom_secrets.yaml",
+				"-filter", "fw-*",
+				"-verbose",
+				"-nopanorama",
+			},
+			expected: &Flags{
+				DebugLevel:     1,
+				Concurrency:    4,
+				ConfigFile:     "custom.yaml",
+				SecretsFile:    "custom_secrets.yaml",
+				HostnameFilter: "fw-*",
+				Verbose:        true,
+				NoPanorama:     true,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fs := flag.NewFlagSet("test", flag.ContinueOnError)
+			cfg := &Flags{}
+			setupFlags(fs, cfg)
+
+			err := fs.Parse(tt.args)
+			require.NoError(t, err)
+
+			assert.Equal(t, tt.expected, cfg)
+		})
+	}
+}

--- a/utils/pdf.go
+++ b/utils/pdf.go
@@ -1,5 +1,5 @@
 // Package pdfgenerate/pdf.go
-package pdfgenerate
+package utils
 
 import (
 	"log"


### PR DESCRIPTION
Create a new flag that allows users to run the execution in "report only" mode, providing a safer way to evaluate the script's functionality without connecting to live remote devices